### PR TITLE
[Property] Expose a new property to items that contain their DIDL descri...

### DIFF
--- a/doc/server/dbus/API.txt
+++ b/doc/server/dbus/API.txt
@@ -808,14 +808,17 @@ Additional property
 |                 |      |      |  implementation detects that a change was |
 |                 |      |      |  made to the resource.                    |
 |---------------------------------------------------------------------------|
+| Metadata        |  s   |  m   |  Contains the Item Metadata information   |
+|                 |      |      |  in DIDL-Lite XML format.                 |
+|---------------------------------------------------------------------------|
 
-Please note that if you want this property to be included in the
+Please note that if you want UpdateCount property to be included in the
 results of a call to one of the List or the Search functions, and you
 are explicitly filtering properties, you must include "Resource" in
 the filter array.  The filter parameter also applies to the contents
 of the returned resources.  So if you specify a filter of ["MIMEType",
 "URL"] the dictionaries in the resources array will contain only these
-properties.
+properties.  Metadata property is not searchable.
 
 
 GetCompatibleResource

--- a/lib/async.h
+++ b/lib/async.h
@@ -46,12 +46,14 @@ struct dls_async_bas_t_ {
 	guint retrieved;
 	guint max_count;
 	dls_async_cb_t get_children_cb;
+	const gchar *metadata;
 };
 
 typedef struct dls_async_get_prop_t_ dls_async_get_prop_t;
 struct dls_async_get_prop_t_ {
 	GCallback prop_func;
 	const gchar *protocol_info;
+	const gchar *metadata;
 };
 
 typedef struct dls_async_get_all_t_ dls_async_get_all_t;
@@ -62,6 +64,7 @@ struct dls_async_get_all_t_ {
 	const gchar *protocol_info;
 	gboolean need_child_count;
 	gboolean device_object;
+	const gchar *metadata;
 };
 
 typedef struct dls_async_upload_t_ dls_async_upload_t;

--- a/lib/device.c
+++ b/lib/device.c
@@ -1110,7 +1110,8 @@ static void prv_found_child(GUPnPDIDLLiteParser *parser,
 		dls_props_add_item(builder->vb, object,
 				   task->target.root_path,
 				   cb_task_data->filter_mask,
-				   cb_task_data->protocol_info);
+				   cb_task_data->protocol_info,
+				   cb_task_data->metadata);
 	}
 
 	g_ptr_array_add(cb_task_data->vbs, builder);
@@ -1226,6 +1227,8 @@ static void prv_get_children_cb(GUPnPServiceProxy *proxy,
 
 	DLEYNA_LOG_DEBUG("GetChildren result: %s", result);
 
+	cb_task_data->metadata = result;
+
 	parser = gupnp_didl_lite_parser_new();
 
 	g_signal_connect(parser, "object-available" ,
@@ -1331,7 +1334,8 @@ static void prv_get_item(GUPnPDIDLLiteParser *parser,
 		dls_props_add_item(cb_task_data->vb, object,
 				   cb_data->task.target.root_path,
 				   DLS_UPNP_MASK_ALL_PROPS,
-				   cb_task_data->protocol_info);
+				   cb_task_data->protocol_info,
+				   cb_task_data->metadata);
 	else
 		cb_data->error = g_error_new(DLEYNA_SERVER_ERROR,
 					     DLEYNA_ERROR_UNKNOWN_INTERFACE,
@@ -1412,7 +1416,8 @@ static void prv_get_all(GUPnPDIDLLiteParser *parser,
 					   object,
 					   cb_data->task.target.root_path,
 					   DLS_UPNP_MASK_ALL_PROPS,
-					   cb_task_data->protocol_info);
+					   cb_task_data->protocol_info,
+					   cb_task_data->metadata);
 		}
 	}
 }
@@ -1850,6 +1855,8 @@ static void prv_get_all_ms2spec_props_cb(GUPnPServiceProxy *proxy,
 
 	DLEYNA_LOG_DEBUG("GetMS2SpecProps result: %s", result);
 
+	cb_task_data->metadata = result;
+
 	parser = gupnp_didl_lite_parser_new();
 
 	g_signal_connect(parser, "object-available" , cb_task_data->prop_func,
@@ -2070,7 +2077,8 @@ static void prv_get_item_property(GUPnPDIDLLiteParser *parser,
 						task_data->prop_name,
 						task->target.root_path,
 						object,
-						cb_task_data->protocol_info);
+						cb_task_data->protocol_info,
+						cb_task_data->metadata);
 
 on_error:
 
@@ -2240,6 +2248,8 @@ static void prv_get_ms2spec_prop_cb(GUPnPServiceProxy *proxy,
 	}
 
 	DLEYNA_LOG_DEBUG("GetMS2SpecProp result: %s", result);
+
+	cb_task_data->metadata = result;
 
 	parser = gupnp_didl_lite_parser_new();
 
@@ -2535,7 +2545,8 @@ static void prv_found_target(GUPnPDIDLLiteParser *parser,
 				   object,
 				   cb_data->task.target.root_path,
 				   cb_task_data->filter_mask,
-				   cb_task_data->protocol_info);
+				   cb_task_data->protocol_info,
+				   cb_task_data->metadata);
 	}
 
 	g_ptr_array_add(cb_task_data->vbs, builder);
@@ -2592,6 +2603,8 @@ static void prv_search_cb(GUPnPServiceProxy *proxy,
 			 G_CALLBACK(prv_found_target), cb_data);
 
 	DLEYNA_LOG_DEBUG("Server Search result: %s", result);
+
+	cb_task_data->metadata = result;
 
 	if (!gupnp_didl_lite_parser_parse_didl(parser, result, &upnp_error) &&
 	    upnp_error->code != GUPNP_XML_ERROR_EMPTY_NODE) {

--- a/lib/interface.h
+++ b/lib/interface.h
@@ -57,6 +57,7 @@ enum dls_interface_type_ {
 #define DLS_INTERFACE_PROP_TRACK_NUMBER "TrackNumber"
 #define DLS_INTERFACE_PROP_ALBUM_ART_URL "AlbumArtURL"
 #define DLS_INTERFACE_PROP_RESOURCES "Resources"
+#define DLS_INTERFACE_PROP_METADATA "Metadata"
 
 /* Container Properties */
 #define DLS_INTERFACE_PROP_SEARCHABLE "Searchable"

--- a/lib/props.h
+++ b/lib/props.h
@@ -61,6 +61,7 @@
 #define DLS_UPNP_MASK_PROP_UPDATE_COUNT			(1LL << 32)
 #define DLS_UPNP_MASK_PROP_CONTAINER_UPDATE_ID		(1LL << 33)
 #define DLS_UPNP_MASK_PROP_TOTAL_DELETED_CHILD_COUNT	(1LL << 34)
+#define DLS_UPNP_MASK_PROP_METADATA			(1LL << 35)
 
 #define DLS_UPNP_MASK_ALL_PROPS 0xffffffffffffffff
 
@@ -121,11 +122,13 @@ void dls_props_add_item(GVariantBuilder *item_vb,
 			GUPnPDIDLLiteObject *object,
 			const gchar *root_path,
 			dls_upnp_prop_mask filter_mask,
-			const gchar *protocol_info);
+			const gchar *protocol_info,
+			const gchar *metadata);
 
 GVariant *dls_props_get_item_prop(const gchar *prop, const gchar *root_path,
 				  GUPnPDIDLLiteObject *object,
-				  const gchar *protocol_info);
+				  const gchar *protocol_info,
+				  const gchar *metadata);
 
 const gchar *dls_props_media_spec_to_upnp_class(const gchar *m2spec_class);
 

--- a/lib/server.c
+++ b/lib/server.c
@@ -333,6 +333,8 @@ static const gchar g_server_introspection[] =
 	"       access='read'/>"
 	"    <property type='aa{sv}' name='"DLS_INTERFACE_PROP_RESOURCES"'"
 	"       access='read'/>"
+	"    <property type='s' name='"DLS_INTERFACE_PROP_METADATA"'"
+	"       access='read'/>"
 	"  </interface>"
 	"  <interface name='"DLEYNA_SERVER_INTERFACE_MEDIA_DEVICE"'>"
 	"    <method name='"DLS_INTERFACE_UPLOAD_TO_ANY"'>"


### PR DESCRIPTION
...ption
- Add a new item property called Metadata which contains the DIDL-Lite XML
  description of the item information. This information could then be passed
  directly to renderers by dLeyna-renderer.
- doc updated.
- Fix issue https://github.com/01org/dleyna-server/issues/25

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
