### PR TITLE
[API] Add new GetMetaData Media Object API

### DIFF
--- a/doc/server/dbus/API.txt
+++ b/doc/server/dbus/API.txt
@@ -497,6 +497,10 @@ The same property cannot appear in both ToAddUpdate and ToDelete.
 Only the following properties can be updated: 'Date', 'DisplayName',
 'Artists', 'Album', 'Type', 'TrackNumber'.
 
+GetMetaData() -> s
+
+Returns the object meta data information in DIDL-Lite XML format.
+
 
 org.gnome.MediaContainer2
 ----------------------

--- a/libdleyna/server/device.h
+++ b/libdleyna/server/device.h
@@ -126,4 +126,8 @@ void dls_device_playlist_upload(dls_client_t *client,
 				dls_task_t *task,
 				const gchar *parent_id);
 
+void dls_device_get_object_metadata(dls_client_t *client,
+				    dls_task_t *task,
+				    const gchar *parent_id);
+
 #endif /* DLS_DEVICE_H__ */

--- a/libdleyna/server/interface.h
+++ b/libdleyna/server/interface.h
@@ -187,5 +187,7 @@ enum dls_interface_type_ {
 #define DLS_INTERFACE_DESCRIPTION "Description"
 #define DLS_INTERFACE_PLAYLIST_ITEMS "PlaylistItems"
 
+#define DLS_INTERFACE_GET_METADATA "GetMetaData"
+#define DLS_INTERFACE_METADATA "MetaData"
 
 #endif /* DLEYNA_SERVER_INTERFACE_H__ */

--- a/libdleyna/server/server.c
+++ b/libdleyna/server/server.c
@@ -138,6 +138,10 @@ static const gchar g_server_introspection[] =
 	"      <arg type='as' name='"DLS_INTERFACE_TO_DELETE"'"
 	"           direction='in'/>"
 	"    </method>"
+	"    <method name='"DLS_INTERFACE_GET_METADATA"'>"
+	"      <arg type='s' name='"DLS_INTERFACE_METADATA"'"
+	"           direction='out'/>"
+	"    </method>"
 	"  </interface>"
 	"  <interface name='"DLS_INTERFACE_MEDIA_CONTAINER"'>"
 	"    <method name='"DLS_INTERFACE_LIST_CHILDREN"'>"
@@ -607,6 +611,9 @@ static void prv_process_async_task(dls_task_t *task)
 		dls_upnp_create_playlist_in_any(g_context.upnp, client, task,
 						prv_async_task_complete);
 		break;
+	case DLS_TASK_GET_OBJECT_METADATA:
+		dls_upnp_get_object_metadata(g_context.upnp, client, task,
+					     prv_async_task_complete);
 	default:
 		break;
 	}
@@ -843,6 +850,8 @@ static void prv_object_method_call(dleyna_connector_id_t conn,
 	else if (!strcmp(method, DLS_INTERFACE_UPDATE))
 		task = dls_task_update_new(invocation, object,
 					   parameters, &error);
+	else if (!strcmp(method, DLS_INTERFACE_GET_METADATA))
+		task = dls_task_get_metadata_new(invocation, object, &error);
 	else
 		goto finished;
 

--- a/libdleyna/server/task.c
+++ b/libdleyna/server/task.c
@@ -530,6 +530,21 @@ finished:
 	return task;
 }
 
+dls_task_t *dls_task_get_metadata_new(dleyna_connector_msg_id_t invocation,
+				const gchar *path, GError **error)
+{
+	dls_task_t *task;
+
+	task = prv_m2spec_task_new(DLS_TASK_GET_OBJECT_METADATA, invocation,
+				   path, "(@s)", error, FALSE);
+	if (!task)
+		goto finished;
+
+finished:
+
+	return task;
+}
+
 void dls_task_complete(dls_task_t *task)
 {
 	GVariant *variant = NULL;

--- a/libdleyna/server/task.h
+++ b/libdleyna/server/task.h
@@ -50,6 +50,7 @@ enum dls_task_type_t_ {
 	DLS_TASK_CREATE_CONTAINER,
 	DLS_TASK_CREATE_CONTAINER_IN_ANY,
 	DLS_TASK_UPDATE_OBJECT,
+	DLS_TASK_GET_OBJECT_METADATA,
 	DLS_TASK_CREATE_PLAYLIST,
 	DLS_TASK_CREATE_PLAYLIST_IN_ANY
 };
@@ -255,6 +256,10 @@ dls_task_t *dls_task_create_playlist_new(dleyna_connector_msg_id_t invocation,
 dls_task_t *dls_task_update_new(dleyna_connector_msg_id_t invocation,
 				const gchar *path, GVariant *parameters,
 				GError **error);
+
+dls_task_t *dls_task_get_metadata_new(dleyna_connector_msg_id_t invocation,
+				      const gchar *path,
+				      GError **error);
 
 void dls_task_cancel(dls_task_t *task);
 

--- a/libdleyna/server/upnp.c
+++ b/libdleyna/server/upnp.c
@@ -1046,6 +1046,23 @@ on_error:
 	DLEYNA_LOG_DEBUG("Exit failure");
 }
 
+void dls_upnp_get_object_metadata(dls_upnp_t *upnp, dls_client_t *client,
+				  dls_task_t *task, dls_upnp_task_complete_t cb)
+{
+	dls_async_task_t *cb_data = (dls_async_task_t *)task;
+
+	DLEYNA_LOG_DEBUG("Enter");
+
+	cb_data->cb = cb;
+
+	DLEYNA_LOG_DEBUG("Root Path %s Id %s", task->target.root_path,
+			 task->target.id);
+
+	dls_device_get_object_metadata(client, task, task->target.id);
+
+	DLEYNA_LOG_DEBUG("Exit");
+}
+
 void dls_upnp_unsubscribe(dls_upnp_t *upnp)
 {
 	GHashTableIter iter;

--- a/libdleyna/server/upnp.h
+++ b/libdleyna/server/upnp.h
@@ -101,6 +101,10 @@ void dls_upnp_create_playlist_in_any(dls_upnp_t *upnp, dls_client_t *client,
 				     dls_task_t *task,
 				     dls_upnp_task_complete_t cb);
 
+void dls_upnp_get_object_metadata(dls_upnp_t *upnp, dls_client_t *client,
+				  dls_task_t *task,
+				  dls_upnp_task_complete_t cb);
+
 void dls_upnp_unsubscribe(dls_upnp_t *upnp);
 
 gboolean dls_upnp_device_context_exist(dls_device_t *device,

--- a/test/dbus/mediaconsole.py
+++ b/test/dbus/mediaconsole.py
@@ -64,6 +64,9 @@ class MediaObject(object):
     def update(self, to_add_update, to_delete):
         return self.__objIF.Update(to_add_update, to_delete)
 
+    def get_metadata(self):
+        return self.__objIF.GetMetaData()
+      
 class Item(MediaObject):
     def __init__(self, path):
         MediaObject.__init__(self, path)


### PR DESCRIPTION
- Add a new method GetMetaData to the org.gnome.UPnP.MediaObject2 interface to allow
  the retrieval of the Meta data information of an object in DIDL-Lite XML format.
- MediaConsole python test app updated.
- Doc updated.
- Fix issue https://github.com/01org/dleyna-server/issues/25

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
