### PR TITLE
[Device] Fix a memory corruption error

### DIFF
--- a/libdleyna/server/device.c
+++ b/libdleyna/server/device.c
@@ -1608,6 +1608,10 @@ static void prv_get_system_update_id_for_props(GUPnPServiceProxy *proxy,
 	g_object_add_weak_pointer((G_OBJECT(proxy)),
 				  (gpointer *)&cb_data->proxy);
 
+	if (cb_data->cancel_id)
+		g_cancellable_disconnect(cb_data->cancellable,
+					 cb_data->cancel_id);
+
 	cb_data->cancel_id = g_cancellable_connect(
 					cb_data->cancellable,
 					G_CALLBACK(dls_async_task_cancelled_cb),
@@ -1801,6 +1805,10 @@ static void prv_get_sr_token_for_props(GUPnPServiceProxy *proxy,
 	cb_data->proxy = proxy;
 	g_object_add_weak_pointer((G_OBJECT(proxy)),
 				  (gpointer *)&cb_data->proxy);
+
+	if (cb_data->cancel_id)
+		g_cancellable_disconnect(cb_data->cancellable,
+					 cb_data->cancel_id);
 
 	cb_data->cancel_id = g_cancellable_connect(
 					cb_data->cancellable,


### PR DESCRIPTION
Fix bug #50.

This bug occurred when nesting service proxy actions, overriding a GObject weak pointer.
