### PR TITLE
[Property] Fix a potential bug when setting Boolean gvariant

### DIFF
--- a/libdleyna/server/props.c
+++ b/libdleyna/server/props.c
@@ -1169,19 +1169,19 @@ static GVariant *prv_props_get_dlna_managed_dict(GUPnPOCMFlags flags)
 
 	g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sb}"));
 
-	managed = (flags & GUPNP_OCM_FLAGS_UPLOAD);
+	managed = (flags & GUPNP_OCM_FLAGS_UPLOAD) != 0;
 	g_variant_builder_add(&builder, "{sb}", "Upload", managed);
 
-	managed = (flags & GUPNP_OCM_FLAGS_CREATE_CONTAINER);
+	managed = (flags & GUPNP_OCM_FLAGS_CREATE_CONTAINER) != 0;
 	g_variant_builder_add(&builder, "{sb}", "CreateContainer", managed);
 
-	managed = (flags & GUPNP_OCM_FLAGS_DESTROYABLE);
+	managed = (flags & GUPNP_OCM_FLAGS_DESTROYABLE) != 0;
 	g_variant_builder_add(&builder, "{sb}", "Delete", managed);
 
-	managed = (flags & GUPNP_OCM_FLAGS_UPLOAD_DESTROYABLE);
+	managed = (flags & GUPNP_OCM_FLAGS_UPLOAD_DESTROYABLE) != 0;
 	g_variant_builder_add(&builder, "{sb}", "UploadDelete", managed);
 
-	managed = (flags & GUPNP_OCM_FLAGS_CHANGE_METADATA);
+	managed = (flags & GUPNP_OCM_FLAGS_CHANGE_METADATA) != 0;
 	g_variant_builder_add(&builder, "{sb}", "ChangeMeta", managed);
 
 	return g_variant_builder_end(&builder);


### PR DESCRIPTION
When setting a gboolean as the result of a bitfield operation,
the result could not be used directly in GVariant, using
g_variant_new_boolean or a call like
g_variant_builder_add(vb, "{sv}", key, g_variant_new_boolean(value));

gboolean is defined as gint
g_variant_new_boolean call internal function that only copy the first
byte of the gboolean.

ex:
gboolean x = 0x00000010 will work, and the GVariant = 0x10
gboolean x = 0x01000000 won't work. GVariant = 0;

We should not do: gboolean x = (x & y)
We must do: gboolean x = (x & y) != 0

Signed-off-by: Ludovic Ferrandis ludovic.ferrandis@intel.com
