### PR TITLE
[Properties] dLeyna-server now handles invalid types.

### DIFF
--- a/libdleyna/server/props.c
+++ b/libdleyna/server/props.c
@@ -1047,6 +1047,9 @@ const gchar *dls_props_media_spec_to_upnp_class(const gchar *m2spec_class)
 {
 	const gchar *retval = NULL;
 
+	if (!m2spec_class)
+		goto on_error;
+
 	if (!strcmp(m2spec_class, gMediaSpec2AlbumPhoto))
 		retval = gUPnPPhotoAlbum;
 	else if (!strcmp(m2spec_class, gMediaSpec2AlbumMusic))
@@ -1090,6 +1093,8 @@ const gchar *dls_props_media_spec_to_upnp_class(const gchar *m2spec_class)
 	else if (!strcmp(m2spec_class, gMediaSpec2Item))
 		retval = gUPnPItem;
 
+on_error:
+
 	return retval;
 }
 
@@ -1097,6 +1102,9 @@ const gchar *dls_props_upnp_class_to_media_spec(const gchar *upnp_class)
 {
 	const gchar *retval = NULL;
 	const gchar *ptr;
+
+	if (!upnp_class)
+		goto on_error;
 
 	if (!strncmp(upnp_class, gUPnPAlbum, gUPnPAlbumLen)) {
 		ptr = upnp_class + gUPnPAlbumLen;
@@ -1158,6 +1166,8 @@ const gchar *dls_props_upnp_class_to_media_spec(const gchar *upnp_class)
 		if (!*ptr || *ptr == '.')
 			retval = gMediaSpec2Item;
 	}
+
+on_error:
 
 	return retval;
 }

--- a/libdleyna/server/task.c
+++ b/libdleyna/server/task.c
@@ -91,7 +91,8 @@ static void prv_delete(dls_task_t *task)
 	case DLS_TASK_CREATE_CONTAINER_IN_ANY:
 		g_free(task->ut.create_container.display_name);
 		g_free(task->ut.create_container.type);
-		g_variant_unref(task->ut.create_container.child_types);
+		if (task->ut.create_container.child_types)
+			g_variant_unref(task->ut.create_container.child_types);
 		break;
 	case DLS_TASK_UPDATE_OBJECT:
 		if (task->ut.update.to_add_update)

--- a/libdleyna/server/upnp.c
+++ b/libdleyna/server/upnp.c
@@ -916,6 +916,9 @@ void dls_upnp_create_container(dls_upnp_t *upnp, dls_client_t *client,
 
 	dls_device_create_container(client, task, task->target.id);
 
+	if (!cb_data->action)
+		(void) g_idle_add(dls_async_task_complete, cb_data);
+
 	DLEYNA_LOG_DEBUG("Exit");
 }
 


### PR DESCRIPTION
Previously, invalid types were not handled correctly which could lead
to crashes when processing invalid meta data or when an invalid type
is passed from applications, in the create container function for
example.

See https://github.com/01org/dleyna-renderer/issues/30 for more details

Signed-off-by: Mark Ryan mark.d.ryan@intel.com
