### PR TITLE
[MediaConsole] Added methods for creating servers

### DIFF
--- a/test/dbus/mediaconsole.py
+++ b/test/dbus/mediaconsole.py
@@ -203,6 +203,25 @@ class UPNP(object):
                 '/com/intel/dLeynaServer'),
                                         'com.intel.dLeynaServer.Manager')
 
+    def server_from_name(self, friendly_name):
+        retval = None
+        for i in self._manager.GetServers():
+            server = Device(i)
+            server_name = server.get_prop("FriendlyName").lower()
+            if server_name.find(friendly_name.lower()) != -1:
+                retval = server
+                break
+        return retval
+
+    def server_from_udn(self, udn):
+        retval = None
+        for i in self._manager.GetServers():
+            server = Device(i)
+            if server.get_prop("UDN") == udn:
+                retval = server
+                break
+        return retval
+
     def servers(self):
         for i in self._manager.GetServers():
             try:


### PR DESCRIPTION
Two new methods have been added to the UPNP class, server_from_name and
server_from_udn.  These methods can be used to construct Device objects
from UDNs or friendly names, which is typically easier than using
the d-Bus path, which is long and changes from one invocation of
dLeyna-server to the next.

Signed-off-by: Mark Ryan mark.d.ryan@intel.com
