### PR TITLE
[Cleanup] Code cleanup after code review

### DIFF
--- a/libdleyna/server/task.c
+++ b/libdleyna/server/task.c
@@ -42,7 +42,6 @@ dls_task_t *dls_task_get_version_new(dleyna_connector_msg_id_t invocation)
 	task->type = DLS_TASK_GET_VERSION;
 	task->invocation = invocation;
 	task->result_format = "(@s)";
-	task->result = g_variant_ref_sink(g_variant_new_string(VERSION));
 	task->synchronous = TRUE;
 
 	return task;


### PR DESCRIPTION
- Don't initialize result in task creation.
  Avoid specific cases. It doesn't make the code more readable, nor smaller.
- if/else cleaning.
  Make default action in if statement, and error management in else statement.
  Most common usage.
- Factorize code.
  Move same function call from each switch/case, outside the switch.
  Reduce code.

Signed-off-by: Ludovic Ferrandis ludovic.ferrandis@intel.com
