### PR TITLE
[Bug Fix] Use object id instead of the parent id for detecting root obje...

### DIFF
--- a/libdleyna/server/device.c
+++ b/libdleyna/server/device.c
@@ -1430,11 +1430,15 @@ static void prv_get_object(GUPnPDIDLLiteParser *parser,
 	const char *parent_path;
 	gchar *path = NULL;
 
-	id = gupnp_didl_lite_object_get_parent_id(object);
+	id = gupnp_didl_lite_object_get_id(object);
+	if (!id)
+		goto on_error;
 
-	if (!id || !strcmp(id, "-1") || !strcmp(id, "")) {
+	if (!strcmp(id, "0")) {
 		parent_path = cb_data->task.target.root_path;
 	} else {
+		id = gupnp_didl_lite_object_get_parent_id(object);
+
 		path = dls_path_from_id(cb_data->task.target.root_path, id);
 		parent_path = path;
 	}
@@ -1442,10 +1446,19 @@ static void prv_get_object(GUPnPDIDLLiteParser *parser,
 	if (!dls_props_add_object(cb_task_data->vb, object,
 				  cb_data->task.target.root_path,
 				  parent_path, DLS_UPNP_MASK_ALL_PROPS))
-		cb_data->error = g_error_new(DLEYNA_SERVER_ERROR,
-					     DLEYNA_ERROR_BAD_RESULT,
-					     "Unable to retrieve mandatory object properties");
+		goto on_error;
+
 	g_free(path);
+
+	return;
+
+on_error:
+
+	g_free(path);
+
+	cb_data->error = g_error_new(DLEYNA_SERVER_ERROR,
+				     DLEYNA_ERROR_BAD_RESULT,
+				     "Unable to retrieve mandatory object properties");
 }
 
 static void prv_get_all(GUPnPDIDLLiteParser *parser,
@@ -2588,11 +2601,15 @@ static void prv_found_target(GUPnPDIDLLiteParser *parser,
 
 	builder = g_new0(dls_device_object_builder_t, 1);
 
-	id = gupnp_didl_lite_object_get_parent_id(object);
+	id = gupnp_didl_lite_object_get_id(object);
+	if (!id)
+		goto on_error;
 
-	if (!id || !strcmp(id, "-1") || !strcmp(id, "")) {
+	if (!strcmp(id, "0")) {
 		parent_path = cb_data->task.target.root_path;
 	} else {
+		id = gupnp_didl_lite_object_get_parent_id(object);
+
 		path = dls_path_from_id(cb_data->task.target.root_path, id);
 		parent_path = path;
 	}

--- a/libdleyna/server/props.c
+++ b/libdleyna/server/props.c
@@ -1720,19 +1720,24 @@ GVariant *dls_props_get_object_prop(const gchar *prop, const gchar *root_path,
 	guint uint_val;
 
 	if (!strcmp(prop, DLS_INTERFACE_PROP_PARENT)) {
-		id = gupnp_didl_lite_object_get_parent_id(object);
-		if (!id || !strcmp(id, "-1")) {
+		id = gupnp_didl_lite_object_get_id(object);
+		if (!id)
+			goto on_error;
+
+		if (!strcmp(id, "0")) {
 			DLEYNA_LOG_DEBUG("Prop %s = %s", prop, root_path);
 
 			retval = g_variant_ref_sink(g_variant_new_string(
-							    root_path));
+								root_path));
 		} else {
+			id = gupnp_didl_lite_object_get_parent_id(object);
+
 			path = dls_path_from_id(root_path, id);
 
 			DLEYNA_LOG_DEBUG("Prop %s = %s", prop, path);
 
 			retval = g_variant_ref_sink(g_variant_new_string(
-							    path));
+								path));
 			g_free(path);
 		}
 	} else if (!strcmp(prop, DLS_INTERFACE_PROP_PATH)) {


### PR DESCRIPTION
...ct

Use object id instead of the parent id to detect if we are at the root
object or not.
This workaround the case where root have an empty string as parent id
value but avoid to return an invalid object path.
According to the specification root parent id must have a "-1" value.

Fix issue: https://github.com/01org/dleyna-server/issues/32

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
