### PR TITLE
[Bug Fix] Use object and parent id values for detecting root object

### DIFF
--- a/libdleyna/server/device.c
+++ b/libdleyna/server/device.c
@@ -1426,25 +1426,41 @@ static void prv_get_object(GUPnPDIDLLiteParser *parser,
 {
 	dls_async_task_t *cb_data = user_data;
 	dls_async_get_all_t *cb_task_data = &cb_data->ut.get_all;
-	const char *id;
+	const char *object_id;
+	const char *parent_id;
 	const char *parent_path;
 	gchar *path = NULL;
 
-	id = gupnp_didl_lite_object_get_parent_id(object);
+	object_id = gupnp_didl_lite_object_get_id(object);
+	if (!object_id)
+		goto on_error;
 
-	if (!id || !strcmp(id, "-1") || !strcmp(id, "")) {
+	parent_id = gupnp_didl_lite_object_get_parent_id(object);
+	if (!parent_id)
+		goto on_error;
+
+	if (!strcmp(object_id, "0") || !strcmp(parent_id, "-1")) {
 		parent_path = cb_data->task.target.root_path;
 	} else {
-		path = dls_path_from_id(cb_data->task.target.root_path, id);
+		path = dls_path_from_id(cb_data->task.target.root_path,
+					parent_id);
 		parent_path = path;
 	}
 
 	if (!dls_props_add_object(cb_task_data->vb, object,
 				  cb_data->task.target.root_path,
 				  parent_path, DLS_UPNP_MASK_ALL_PROPS))
-		cb_data->error = g_error_new(DLEYNA_SERVER_ERROR,
-					     DLEYNA_ERROR_BAD_RESULT,
-					     "Unable to retrieve mandatory object properties");
+		goto on_error;
+
+	g_free(path);
+
+	return;
+
+on_error:
+
+	cb_data->error = g_error_new(DLEYNA_SERVER_ERROR,
+				     DLEYNA_ERROR_BAD_RESULT,
+				     "Unable to retrieve mandatory object properties");
 	g_free(path);
 }
 
@@ -2578,7 +2594,8 @@ static void prv_found_target(GUPnPDIDLLiteParser *parser,
 {
 	dls_async_task_t *cb_data = user_data;
 	dls_async_bas_t *cb_task_data = &cb_data->ut.bas;
-	const char *id;
+	const char *object_id;
+	const char *parent_id;
 	const char *parent_path;
 	gchar *path = NULL;
 	gboolean have_child_count;
@@ -2588,12 +2605,19 @@ static void prv_found_target(GUPnPDIDLLiteParser *parser,
 
 	builder = g_new0(dls_device_object_builder_t, 1);
 
-	id = gupnp_didl_lite_object_get_parent_id(object);
+	object_id = gupnp_didl_lite_object_get_id(object);
+	if (!object_id)
+		goto on_error;
 
-	if (!id || !strcmp(id, "-1") || !strcmp(id, "")) {
+	parent_id = gupnp_didl_lite_object_get_parent_id(object);
+	if (!parent_id)
+		goto on_error;
+
+	if (!strcmp(object_id, "0") || !strcmp(parent_id, "-1")) {
 		parent_path = cb_data->task.target.root_path;
 	} else {
-		path = dls_path_from_id(cb_data->task.target.root_path, id);
+		path = dls_path_from_id(cb_data->task.target.root_path,
+					parent_id);
 		parent_path = path;
 	}
 

--- a/libdleyna/server/props.c
+++ b/libdleyna/server/props.c
@@ -1709,7 +1709,8 @@ on_exit:
 GVariant *dls_props_get_object_prop(const gchar *prop, const gchar *root_path,
 				    GUPnPDIDLLiteObject *object)
 {
-	const char *id;
+	const char *object_id;
+	const char *parent_id;
 	gchar *path;
 	const char *upnp_class;
 	const char *media_spec_type;
@@ -1720,14 +1721,21 @@ GVariant *dls_props_get_object_prop(const gchar *prop, const gchar *root_path,
 	guint uint_val;
 
 	if (!strcmp(prop, DLS_INTERFACE_PROP_PARENT)) {
-		id = gupnp_didl_lite_object_get_parent_id(object);
-		if (!id || !strcmp(id, "-1")) {
+		object_id = gupnp_didl_lite_object_get_id(object);
+		if (!object_id)
+			goto on_error;
+
+		parent_id = gupnp_didl_lite_object_get_parent_id(object);
+		if (!parent_id)
+			goto on_error;
+
+		if (!strcmp(object_id, "0") || !strcmp(parent_id, "-1")) {
 			DLEYNA_LOG_DEBUG("Prop %s = %s", prop, root_path);
 
 			retval = g_variant_ref_sink(g_variant_new_string(
 							    root_path));
 		} else {
-			path = dls_path_from_id(root_path, id);
+			path = dls_path_from_id(root_path, parent_id);
 
 			DLEYNA_LOG_DEBUG("Prop %s = %s", prop, path);
 
@@ -1736,11 +1744,11 @@ GVariant *dls_props_get_object_prop(const gchar *prop, const gchar *root_path,
 			g_free(path);
 		}
 	} else if (!strcmp(prop, DLS_INTERFACE_PROP_PATH)) {
-		id = gupnp_didl_lite_object_get_id(object);
-		if (!id)
+		object_id = gupnp_didl_lite_object_get_id(object);
+		if (!object_id)
 			goto on_error;
 
-		path = dls_path_from_id(root_path, id);
+		path = dls_path_from_id(root_path, object_id);
 
 		DLEYNA_LOG_DEBUG("Prop %s = %s", prop, path);
 


### PR DESCRIPTION
Change the way to identify root object.

We now use both object and parent ids values.

Object with a "0" object id value or a "-1" parent id value will
be considered as root object.

Reasons for accepting both:
a) there's code out there where root parent_id != -1 and
b) there's also code out there where root-like (parentless)
   objects id != 0.

Object with a "0" id value or a "-1" parent id value

This fixes the case of issue #32 where root have an empty string as
parent id value.

According to the specification root parent id must have a "-1" value.

Fix issue: https://github.com/01org/dleyna-server/issues/32

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
