### PR TITLE
[Props] Added the new TypeEx property and fixed Type

### DIFF
--- a/doc/server/dbus/API.txt
+++ b/doc/server/dbus/API.txt
@@ -262,13 +262,13 @@ not necessarily finished.  There are two return values.  The UploadId,
 which can be used to monitor the progress of the upload and to
 cancel it and ObjectPath, which contains the path of the newly created object.
 
-CreateContainerInAnyContainer(s DisplayName, s Type, as ChildTypes)
+CreateContainerInAnyContainer(s DisplayName, s TypeEx, as ChildTypes)
                                                              -> o ObjectPath
 
 Creates a new container. The DMS chooses the best place to create
 this new container. DisplayName is the name of the new container,
-Type is the type and ChildTypes is an array of types that can be stored
-in the new folder, e.g., ['video','container'].
+TypeEx is the extended type and ChildTypes is an array of extended types that
+can be stored in the new folder, e.g., ['video','container'].
 A special value of ['*'] indicates that no restriction is placed
 on the types of objects that can be stored in the container.
 The path of the newly created object is returned.
@@ -361,7 +361,7 @@ The value of each dictionary entry depends on the key value.
 | o | M | Contains the Object Path property of the parent container to which   |
 |   |   | this object was added.                                               |
 |------------------------------------------------------------------------------|
-| s | M | Contains the value of the Type (converted upnp:class property)       |
+| s | M | Contains the value of the TypeEx (converted upnp:class property)     |
 |   |   | of the object that was added.                                        |
 |------------------------------------------------------------------------------|
 
@@ -482,6 +482,24 @@ Additional Properties:
 |                 |       |      |  for the object relative to the          |
 |                 |       |      |  SystemUpdateID state variable.          |
 |---------------------------------------------------------------------------|
+| TypeEx          |  s    |  m   |  The extended Type of the object.        |
+|                 |       |      |  following values are permitted:         |
+|                 |       |      |                                          |
+|                 |       |      |  in case of Items:                       |
+|                 |       |      |   'video.musicclip', 'video.broadcast'   |
+|                 |       |      |   'audio.broadcast', 'audio.book',       |
+|                 |       |      |   'item.playlist', 'item', 'video',      |
+|                 |       |      |   'video.movie', 'audio', 'music',       |
+|                 |       |      |   'image', 'image.photo'                 |
+|                 |       |      |  and in case of Containers:              |
+|                 |       |      |   'album', 'album.music', 'album.photo'  |
+|                 |       |      |   'person', 'person.musicartist'         |
+|                 |       |      |   'genre', 'genre.music', 'genre.movie'  |
+|                 |       |      |   'playlist', 'storage', 'container'     |
+|                 |       |      |                                          |
+|                 |       |      |  Since version 0.2.0.                    |
+|---------------------------------------------------------------------------|
+
 
 
 Additional Methods:
@@ -502,7 +520,7 @@ property name value pairs that are to be updated, or added if they do
 not already exist.  ToDelete is an array of properties to be deleted.
 The same property cannot appear in both ToAddUpdate and ToDelete.
 Only the following properties can be updated: 'Date', 'DisplayName',
-'Artists', 'Album', 'Type', 'TrackNumber'.
+'Artists', 'Album', 'TypeEx', 'TrackNumber'.
 
 GetMetaData() -> s
 
@@ -548,12 +566,21 @@ Additional properties unsupported by org.gnome.MediaContainer2
 |---------------------------------------------------------------------------|
 |     Name               | Type | m/o* |              Description           |
 |---------------------------------------------------------------------------|
-| CreateClasses          |a(sb) |  o   |  Array of UPnP createClasses       |
-|                        |      |      |  property. A createClasses         |
-|                        |      |      |  property is a tuple (sb)          |
-|                        |      |      |  representing the class and        |
-|                        |      |      |  whether derived values are        |
-|                        |      |      |  allowed for this class.           |
+| CreateClasses          |a(sb) |  o   |  The CreateClasses property is an  |      
+|                        |      |      |  array of tuples (sb) that lists   |
+|                        |      |      |  the extended types of objects that|
+|                        |      |      |  that can be created in a          |
+|                        |      |      |  container. A boolean value is     |
+|                        |      |      |  associated with each type.  This  |
+|                        |      |      |  boolean indicates whether objects |
+|                        |      |      |  of types derived from the         |
+|                        |      |      |  specified extended type can also  |
+|                        |      |      |  be created in this container.     |
+|                        |      |      |  For example, ("album","true")     |
+|                        |      |      |  would indicate that objects of    |
+|                        |      |      |  type album, album.music and       |
+|                        |      |      |  album.photo can be created in the |
+|                        |      |      |  container.                        |
 |---------------------------------------------------------------------------|
 | ContainerUpdateID      |  u   |  o   |  Contains the value of the         |
 |                        |      |      |  SystemUpdateID state variable     |
@@ -607,7 +634,7 @@ SearchObjectsEx(s Query, u Offset, u Max, as Filter, s SortBy) -> aa{sv}
 
 Upload(s DisplayName, s FilePath) -> (u UploadId, o ObjectPath)
 
-CreateContainer(s DisplayName, s Type, as ChildTypes) -> o ObjectPath
+CreateContainer(s DisplayName, s TypeEx, as ChildTypes) -> o ObjectPath
 
 CreateReference(o ObjectPath) -> o ObjectPath
 
@@ -676,8 +703,8 @@ suitable location for the file.
 
 The CreateContainer method creates a new child container.
 DisplayName is the name of the new container,
-Type is the type and ChildTypes is an array of types that can be stored
-in the new folder, e.g., ['video','container'].
+TypeEx is the extended type and ChildTypes is an array of extended 
+types that can be stored in the new folder, e.g., ['video','container'].
 A special value of ['*'] indicates that no restriction is placed
 on the types of objects that can be stored in the container.
 The path of the newly created object is returned.

--- a/libdleyna/server/device.c
+++ b/libdleyna/server/device.c
@@ -295,7 +295,7 @@ static void prv_last_change_decode(GUPnPCDSLastChangeEntry *entry,
 		if (!mclass)
 			goto on_error;
 
-		media_class = dls_props_upnp_class_to_media_spec(mclass);
+		media_class = dls_props_upnp_class_to_media_spec_ex(mclass);
 		if (!media_class)
 			goto on_error;
 
@@ -769,8 +769,18 @@ static void prv_get_capabilities_analyze(GHashTable *property_map,
 		while (caps && *caps) {
 			prop_name = g_hash_table_lookup(property_map, *caps);
 
-			if (prop_name)
+			if (prop_name) {
 				g_variant_builder_add(&caps_vb, "s", prop_name);
+
+				/* TODO: Okay this is not very nice.  A better
+				   way to fix this would be to change the p_map
+				   to be many : many. */
+
+				if (!strcmp(*caps, "upnp:class"))
+					g_variant_builder_add(
+						&caps_vb, "s",
+						DLS_INTERFACE_PROP_TYPE_EX);
+			}
 
 			caps++;
 		}
@@ -2862,7 +2872,7 @@ static gchar *prv_create_new_container_didl(const gchar *parent_id,
 	GUPnPOCMFlags flags;
 	gchar *retval = NULL;
 
-	actual_type = dls_props_media_spec_to_upnp_class(
+	actual_type = dls_props_media_spec_to_upnp_class_ex(
 						task->ut.create_container.type);
 	if (!actual_type)
 		goto on_error;
@@ -2890,7 +2900,7 @@ static gchar *prv_create_new_container_didl(const gchar *parent_id,
 
 	g_variant_iter_init(&iter, task->ut.create_container.child_types);
 	while ((child_type = g_variant_iter_next_value(&iter))) {
-		actual_type = dls_props_media_spec_to_upnp_class(
+		actual_type = dls_props_media_spec_to_upnp_class_ex(
 					g_variant_get_string(child_type, NULL));
 		if (actual_type != NULL)
 			gupnp_didl_lite_container_add_create_class(container,
@@ -3785,7 +3795,7 @@ static gchar *prv_get_current_xml_fragment(GUPnPDIDLLiteObject *object,
 		retval = gupnp_didl_lite_object_get_album_xml_string(object);
 	else if (mask & DLS_UPNP_MASK_PROP_DATE)
 		retval = gupnp_didl_lite_object_get_date_xml_string(object);
-	else if (mask & DLS_UPNP_MASK_PROP_TYPE)
+	else if (mask & DLS_UPNP_MASK_PROP_TYPE_EX)
 		retval = gupnp_didl_lite_object_get_upnp_class_xml_string(
 			object);
 	else if (mask & DLS_UPNP_MASK_PROP_TRACK_NUMBER)
@@ -3825,9 +3835,9 @@ static gchar *prv_get_new_xml_fragment(GUPnPDIDLLiteObject *object,
 					g_variant_get_string(value, NULL));
 
 		retval = gupnp_didl_lite_object_get_date_xml_string(object);
-	} else if (mask & DLS_UPNP_MASK_PROP_TYPE) {
-		upnp_class = dls_props_media_spec_to_upnp_class(
-					g_variant_get_string(value, NULL));
+	} else if (mask & DLS_UPNP_MASK_PROP_TYPE_EX) {
+		upnp_class = dls_props_media_spec_to_upnp_class_ex(
+			g_variant_get_string(value, NULL));
 		if (!upnp_class)
 			goto on_error;
 

--- a/libdleyna/server/interface.h
+++ b/libdleyna/server/interface.h
@@ -43,6 +43,7 @@ enum dls_interface_type_ {
 #define DLS_INTERFACE_PROP_RESTRICTED "Restricted"
 #define DLS_INTERFACE_PROP_DISPLAY_NAME "DisplayName"
 #define DLS_INTERFACE_PROP_TYPE "Type"
+#define DLS_INTERFACE_PROP_TYPE_EX "TypeEx"
 #define DLS_INTERFACE_PROP_CREATOR "Creator"
 #define DLS_INTERFACE_PROP_DLNA_MANAGED "DLNAManaged"
 #define DLS_INTERFACE_PROP_OBJECT_UPDATE_ID "ObjectUpdateID"

--- a/libdleyna/server/props.h
+++ b/libdleyna/server/props.h
@@ -64,6 +64,7 @@
 #define DLS_UPNP_MASK_PROP_DLNA_CONVERSION		(1LL << 35)
 #define DLS_UPNP_MASK_PROP_DLNA_OPERATION		(1LL << 36)
 #define DLS_UPNP_MASK_PROP_DLNA_FLAGS			(1LL << 37)
+#define DLS_UPNP_MASK_PROP_TYPE_EX			(1LL << 38)
 
 #define DLS_UPNP_MASK_ALL_PROPS 0xffffffffffffffff
 
@@ -134,6 +135,10 @@ GVariant *dls_props_get_item_prop(const gchar *prop, const gchar *root_path,
 
 const gchar *dls_props_media_spec_to_upnp_class(const gchar *m2spec_class);
 
+const gchar *dls_props_media_spec_to_upnp_class_ex(const gchar *m2spec_class);
+
 const gchar *dls_props_upnp_class_to_media_spec(const gchar *upnp_class);
+
+const gchar *dls_props_upnp_class_to_media_spec_ex(const gchar *upnp_class);
 
 #endif /* DLS_PROPS_H__ */

--- a/libdleyna/server/search.c
+++ b/libdleyna/server/search.c
@@ -80,6 +80,17 @@ gchar *dls_search_translate_search_string(GHashTable *filter_map,
 				goto on_error;
 			g_free(value);
 			value = g_strdup_printf("\"%s\"", translated_value);
+		} else if (!strcmp(prop, DLS_INTERFACE_PROP_TYPE_EX)) {
+			/* Skip the quotes */
+
+			value[strlen(value) - 1] = 0;
+			translated_value =
+				dls_props_media_spec_to_upnp_class_ex(
+					value + 1);
+			if (!translated_value)
+				goto on_error;
+			g_free(value);
+			value = g_strdup_printf("\"%s\"", translated_value);
 		} else if (!strcmp(prop, DLS_INTERFACE_PROP_PARENT) ||
 			   !strcmp(prop, DLS_INTERFACE_PROP_PATH)) {
 			value[strlen(value) - 1] = 0;

--- a/libdleyna/server/server.c
+++ b/libdleyna/server/server.c
@@ -120,6 +120,8 @@ static const gchar g_server_introspection[] =
 	"       access='read'/>"
 	"    <property type='s' name='"DLS_INTERFACE_PROP_TYPE"'"
 	"       access='read'/>"
+	"    <property type='s' name='"DLS_INTERFACE_PROP_TYPE_EX"'"
+	"       access='read'/>"
 	"    <property type='o' name='"DLS_INTERFACE_PROP_PATH"'"
 	"       access='read'/>"
 	"    <property type='s' name='"DLS_INTERFACE_PROP_DISPLAY_NAME"'"


### PR DESCRIPTION
This PR fixes a long standing bug in the dleyna-server API.

The Type property is now consistent with the MediaServer2Spec Type
property.  This should remove the source of constant confusion and
fix a number of bugs, in for example the download sync controller.

A new property, TypeEx has been introduced.  TypeEx contains the
extended type information for an object, i.e., the value Type used
to hold, so if applications want the extended type they can still
retrieve it.

Both Type and TypeEx are searchable.  The superset of values specified
by TypeEx are permitted when creating a container, both in the type
of the container and it its create classes.

The extended type is exposed in the CreateClasses of a container and in
the LastChange event.

Type is no longer permitted in Update.  TypeEx must be used.

From an API point of view there are two breakagaes:
1. Applications that used Type to retrieve extended type information,
   need to be updated to use TypeEx.
2. Applications that updated the Type of an object will need to be
   updated to use TypeEx instead.

There is one slightly unpleasent hack required to report the correct
values for Search and Sort Caps.  A correct solution would require
making the p_map hash table many to many, which would result in a bigger
change.  I've left this improvement for another commit.

Signed-off-by: Mark Ryan mark.d.ryan@intel.com
