### PR TITLE
[Control Point] Get control point version

### DIFF
--- a/libdleyna/server/server.c
+++ b/libdleyna/server/server.c
@@ -1372,6 +1372,11 @@ static const gchar *prv_control_point_root_introspection(void)
 	return g_root_introspection;
 }
 
+static const gchar *prv_control_point_get_version(void)
+{
+	return VERSION;
+}
+
 static const dleyna_control_point_t g_control_point = {
 	prv_control_point_initialize,
 	prv_control_point_free,
@@ -1379,7 +1384,8 @@ static const dleyna_control_point_t g_control_point = {
 	prv_control_point_server_introspection,
 	prv_control_point_root_introspection,
 	prv_control_point_start_service,
-	prv_control_point_stop_service
+	prv_control_point_stop_service,
+	prv_control_point_get_version
 };
 
 const dleyna_control_point_t *dleyna_control_point_get_server(void)

--- a/server/daemon.c
+++ b/server/daemon.c
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
 	if (!prv_init_signal_handler(mask))
 		goto out;
 
-	retval = dleyna_main_loop_start(DLS_SERVER_SERVICE_NAME, VERSION,
+	retval = dleyna_main_loop_start(DLS_SERVER_SERVICE_NAME,
 					dleyna_control_point_get_server(),
 					NULL);
 


### PR DESCRIPTION
Fix issue 01org/dleyna-core#29

We currently log the daemon version string, but the control point version string should be printed instead.
The full fix requires changes in dleyna-core, dleyna-server & dleyna-renderer.
This PR is the second step.
