### PR TITLE
upnp: Use "port" setting when creating GUPnPContextManager

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ AC_ARG_ENABLE(master-build,,
 		[master_build=no])
 
 AS_IF([test "x$master_build" = "xno"],
-      [PKG_CHECK_MODULES([DLEYNA_CORE], [dleyna-core-1.0 >= 0.4.0])],
+      [PKG_CHECK_MODULES([DLEYNA_CORE], [dleyna-core-1.0 >= 0.5.0])],
       [this_abs_top_srcdir=`cd "$srcdir" && pwd`;
        DLEYNA_CORE_CFLAGS="-I$this_abs_top_srcdir/../dleyna-core";
        DLEYNA_CORE_LIBS="-L$this_abs_top_srcdir/../dleyna-core/.libs -ldleyna-core-1.0"

--- a/libdleyna/server/dleyna-server-service.conf.in
+++ b/libdleyna/server/dleyna-server-service.conf.in
@@ -12,6 +12,8 @@ never-quit=@never_quit@
 # IPC connector name
 connector-name=@with_connector_name@
 
+# Source port for SSDP messages
+#port=4321
 
 # Log configuration options
 [log]

--- a/libdleyna/server/server.c
+++ b/libdleyna/server/server.c
@@ -1326,6 +1326,7 @@ static gboolean prv_control_point_start_service(
 
 	if (g_context.dls_id[DLS_MANAGER_INTERFACE_MANAGER]) {
 		g_context.upnp = dls_upnp_new(connection,
+					      dleyna_settings_port(g_context.settings),
 					      g_server_vtables,
 					      prv_found_media_server,
 					      prv_lost_media_server,

--- a/libdleyna/server/upnp.c
+++ b/libdleyna/server/upnp.c
@@ -509,6 +509,7 @@ static void prv_on_context_available(GUPnPContextManager *context_manager,
 }
 
 dls_upnp_t *dls_upnp_new(dleyna_connector_id_t connection,
+			 guint port,
 			 const dleyna_connector_dispatch_cb_t *dispatch_table,
 			 dls_upnp_callback_t found_server,
 			 dls_upnp_callback_t lost_server,
@@ -536,7 +537,7 @@ dls_upnp_t *dls_upnp_new(dleyna_connector_id_t connection,
 
 	dls_prop_maps_new(&upnp->property_map, &upnp->filter_map);
 
-	upnp->context_manager = gupnp_context_manager_create(0);
+	upnp->context_manager = gupnp_context_manager_create(port);
 
 	g_signal_connect(upnp->context_manager, "context-available",
 			 G_CALLBACK(prv_on_context_available),

--- a/libdleyna/server/upnp.h
+++ b/libdleyna/server/upnp.h
@@ -32,6 +32,7 @@ typedef void (*dls_upnp_callback_t)(const gchar *path, void *user_data);
 typedef void (*dls_upnp_task_complete_t)(dls_task_t *task, GError *error);
 
 dls_upnp_t *dls_upnp_new(dleyna_connector_id_t connection,
+			 guint port,
 			 const dleyna_connector_dispatch_cb_t *dispatch_table,
 			 dls_upnp_callback_t found_server,
 			 dls_upnp_callback_t lost_server,


### PR DESCRIPTION
Signed-off-by: Jussi Kukkonen jussi.kukkonen@intel.com

See https://github.com/01org/dleyna-core/pull/40 for the dependency.
