### PR TITLE
[Build] Fix out-of-source-tree builds

### DIFF
--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS =	$(GLIB_CFLAGS)				\
 		$(GIO_CFLAGS)				\
 		$(DLEYNA_CORE_CFLAGS)			\
-		-I$(top_builddir)/libdleyna/server	\
+		-I$(top_srcdir)	\
 		-include config.h
 
 libexec_PROGRAMS = dleyna-server-service


### PR DESCRIPTION
The libdleyna-server include path seems to be entirely wrong: Even
with in-tree-builds it wasn't actually useful. Use -I$(top_srcdir)
instead so out-of-source-tree builds succeed.

The same exact problem is in dleyna-renderer: I'll fix that if this seems good.
