### PR TITLE
[Props] Fix ChildCount property type

### DIFF
--- a/libdleyna/server/props.c
+++ b/libdleyna/server/props.c
@@ -622,7 +622,7 @@ static void prv_add_variant_prop(GVariantBuilder *vb, const gchar *key,
 
 void dls_props_add_child_count(GVariantBuilder *item_vb, gint value)
 {
-	prv_add_int_prop(item_vb, DLS_INTERFACE_PROP_CHILD_COUNT, value);
+	prv_add_uint_prop(item_vb, DLS_INTERFACE_PROP_CHILD_COUNT, value);
 }
 
 static void prv_add_bool_prop(GVariantBuilder *vb, const gchar *key,


### PR DESCRIPTION
It's a uint32, not a signed int.

Fixes #145.

I would have just pushed Bastiens fix ... but since I haven't been active in six months I thought it might be polite to go via PR. The other parts of the D-Bus handling code already treat the value as uint so this is just a bug fix: it still leaves the internal interface weird (why is count an int in the first place) but fixes the blatant bug. 