### PR TITLE
Fix possible use-after-free on exit

### DIFF
--- a/libdleyna/server/server.c
+++ b/libdleyna/server/server.c
@@ -1352,12 +1352,15 @@ static void prv_control_point_stop_service(void)
 {
 	uint i;
 
-	if (g_context.manager)
+	if (g_context.manager) {
 		dls_manager_delete(g_context.manager);
+		g_context.manager = NULL;
+	}
 
 	if (g_context.upnp) {
 		dls_upnp_unsubscribe(g_context.upnp);
 		dls_upnp_delete(g_context.upnp);
+		g_context.upnp = NULL;
 	}
 
 	if (g_context.connection) {

--- a/libdleyna/server/upnp.c
+++ b/libdleyna/server/upnp.c
@@ -547,6 +547,9 @@ dls_upnp_t *dls_upnp_new(dleyna_connector_id_t connection,
 void dls_upnp_delete(dls_upnp_t *upnp)
 {
 	if (upnp) {
+		g_signal_handlers_disconnect_by_func (G_OBJECT (upnp->context_manager),
+						      G_CALLBACK(prv_on_context_available),
+						      upnp);
 		g_object_unref(upnp->context_manager);
 		g_hash_table_unref(upnp->property_map);
 		g_hash_table_unref(upnp->filter_map);


### PR DESCRIPTION
When the last client of dleyna-server exits, and dleyna-server
tries to exit, it might use the "upnp" pointer after it was freed as we
receive a signal where the user_data is invalid. Avoid that by zero'ing
freed pointers and disconnecting from the signal for which "upnp" is
user_data.

See https://retrace.fedoraproject.org/faf/reports/855440/