### PR TITLE
Include libgupnp/gupnp-context-manager.h

### DIFF
--- a/libdleyna/server/upnp.h
+++ b/libdleyna/server/upnp.h
@@ -24,6 +24,7 @@
 #define DLS_UPNP_H__
 
 #include <libdleyna/core/connector.h>
+#include <libgupnp/gupnp-context-manager.h>
 
 #include "client.h"
 #include "async.h"


### PR DESCRIPTION
As we make use of the type 'GUPnPContextManager' we need to ensure that
this is known here. Relying on any other random header to being this in
for us is unreliable (and has been seen failing in the wild).